### PR TITLE
Update setup.py to match new virtualenvwrapper.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,7 @@ setup(
 
         install_requires=[
             'virtualenv',
-            'virtualenvwrapper',
-            'virtualenvwrapper.project',
+            'virtualenvwrapper>=2.9',
             ],
 
         entry_points={


### PR DESCRIPTION
Virtualenvwrapper.project was integrated into the main project in 2.9
and setup.py needs to reflect this in order for the github template
to work.
